### PR TITLE
Add loki nodes db small fixes

### DIFF
--- a/packages/gatsby/src/schema/infer-graphql-input-fields.js
+++ b/packages/gatsby/src/schema/infer-graphql-input-fields.js
@@ -211,7 +211,6 @@ const EXCLUDE_KEYS = {
   parent: 1,
   children: 1,
   $loki: 1,
-  meta: 1,
 }
 
 type InferInputOptions = {

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -320,7 +320,6 @@ const EXCLUDE_KEYS = {
   parent: 1,
   children: 1,
   $loki: 1,
-  meta: 1,
 }
 
 // Call this for the top level node + recursively for each sub-object.

--- a/packages/gatsby/src/schema/infer-graphql-type.js
+++ b/packages/gatsby/src/schema/infer-graphql-type.js
@@ -114,21 +114,24 @@ function inferGraphQLType({
       return { type: GraphQLBoolean }
     case `string`:
       return { type: GraphQLString }
-    case `object`:
+    case `object`: {
+      const typeName = createTypeName(fieldName)
       return {
         type: new GraphQLObjectType({
-          name: createTypeName(fieldName),
+          name: typeName,
           fields: _inferObjectStructureFromNodes(
             {
               ...otherArgs,
               selector,
               nodes,
               types,
+              typeName,
             },
             exampleValue
           ),
         }),
       }
+    }
     case `number`:
       return is32BitInteger(exampleValue)
         ? { type: GraphQLInt }
@@ -201,13 +204,7 @@ export function findLinkedNode(value, linkedField, path) {
   return linkedNode
 }
 
-function inferFromFieldName(
-  typeName,
-  fieldName,
-  value,
-  selector,
-  types
-): GraphQLFieldConfig<*, *> {
+function inferFromFieldName(value, selector, types): GraphQLFieldConfig<*, *> {
   let isArray = false
   if (_.isArray(value)) {
     isArray = true
@@ -277,7 +274,6 @@ function inferFromFieldName(
       }
     } else {
       type = fields[0].nodeObjectType
-      lazyFields.add(type.name, fieldName)
     }
 
     return {
@@ -299,7 +295,6 @@ function inferFromFieldName(
   validateLinkedNode(linkedNode)
   const field = findNodeType(linkedNode)
   validateField(linkedNode, field)
-  lazyFields.add(typeName, fieldName)
   return {
     type: field.nodeObjectType,
     resolve: pageDependencyResolver(node =>
@@ -313,6 +308,7 @@ type inferTypeOptions = {
   types: ProcessedNodeType[],
   ignoreFields?: string[],
   selector?: string,
+  typeName?: string,
 }
 
 const EXCLUDE_KEYS = {
@@ -325,7 +321,7 @@ const EXCLUDE_KEYS = {
 // Call this for the top level node + recursively for each sub-object.
 // E.g. This gets called for Markdown and then for its frontmatter subobject.
 function _inferObjectStructureFromNodes(
-  { nodes, types, selector, ignoreFields }: inferTypeOptions,
+  { nodes, types, selector, ignoreFields, typeName }: inferTypeOptions,
   exampleValue: ?Object
 ): GraphQLFieldConfigMap<*, *> {
   const config = store.getState().config
@@ -335,12 +331,15 @@ function _inferObjectStructureFromNodes(
   // Ensure nodes have internal key with object.
   nodes = nodes.map(n => (n.internal ? n : { ...n, internal: {} }))
 
-  const typeName: string = nodes[0].internal.type
+  const rootTypeName: string = nodes[0].internal.type
+  if (!typeName) {
+    typeName = rootTypeName
+  }
 
   let resolvedExample: Object =
     exampleValue != null
       ? exampleValue
-      : getExampleValues({ nodes, typeName, ignoreFields })
+      : getExampleValues({ nodes, typeName: rootTypeName, ignoreFields })
 
   const inferredFields = {}
   _.each(resolvedExample, (value, key) => {
@@ -351,7 +350,7 @@ function _inferObjectStructureFromNodes(
     // Several checks to see if a field is pointing to custom type
     // before we try automatic inference.
     const nextSelector = selector ? `${selector}.${key}` : key
-    const fieldSelector = `${typeName}.${nextSelector}`
+    const fieldSelector = `${rootTypeName}.${nextSelector}`
 
     let fieldName = key
     let inferredField
@@ -365,13 +364,8 @@ function _inferObjectStructureFromNodes(
       // (a node id) to find the node and use that node's type as the field
     } else if (key.includes(`___NODE`)) {
       ;[fieldName] = key.split(`___`)
-      inferredField = inferFromFieldName(
-        typeName,
-        fieldName,
-        value,
-        nextSelector,
-        types
-      )
+      inferredField = inferFromFieldName(value, nextSelector, types)
+      lazyFields.add(typeName, fieldName)
     }
 
     // Replace unsupported values

--- a/packages/gatsby/src/schema/lazy-fields.js
+++ b/packages/gatsby/src/schema/lazy-fields.js
@@ -25,11 +25,11 @@ const { GraphQLList, GraphQLObjectType } = require(`graphql`)
 // sift, rather than loki, so not a big deal
 const typeFields = new Map()
 
-function contains(filters, queryType, fieldType = queryType) {
+function contains(filters, fieldType) {
   return _.some(filters, (fieldFilter, fieldName) => {
     // If a field has been previously flagged as a lazy field, then
     // return true
-    const storedFields = typeFields.get(queryType.name)
+    const storedFields = typeFields.get(fieldType.name)
     if (storedFields && storedFields.has(fieldName)) {
       return true
     } else {
@@ -37,12 +37,12 @@ function contains(filters, queryType, fieldType = queryType) {
       // nodes, in which case we might filter via an elemMatch
       // field. Or, it might be a nested linked object. In either
       // case, we recurse
-      const gqlFieldType = fieldType.getFields()[fieldName].type
+      const gqlFieldType = fieldType.getFields()[fieldName]?.type
       if (gqlFieldType) {
         if (gqlFieldType instanceof GraphQLList && fieldFilter.elemMatch) {
-          return contains(fieldFilter.elemMatch, queryType, gqlFieldType.ofType)
+          return contains(fieldFilter.elemMatch, gqlFieldType.ofType)
         } else if (gqlFieldType instanceof GraphQLObjectType) {
-          return contains(fieldFilter, queryType, gqlFieldType)
+          return contains(fieldFilter, gqlFieldType)
         }
       }
     }


### PR DESCRIPTION
just couple (hopefully) small fixes:
 - don't skip `meta` field when generating schema (after disabling it in loki)
 - lazy fields for nested properties could produce false positives - they were storing leafs field in main type:
```
{
    id: 'node_B',
    test: `this should not be in lazy fields`,
    nested: {
      test___NODE: `node_a`,
    },
    internal: {
      type: 'NodeB',
      contentDigest: `node_B`,
    },
  }
```
was storing just `test` inside `NodeB` lazy fields which would force sift when filtering by root `test` field. My change will add `test` field to type created for `nested` object and `lazyfields.contains` function was adjusted for it